### PR TITLE
Add basic SIM management CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+sims.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # smsbox
+
+This project implements a simple SIM management system with a command line
+interface. You can add, list, assign, block and remove SIM cards. Data is stored
+in a JSON file `sims.json` by default.
+
+## Usage
+
+Run the CLI using Python:
+
+```bash
+python -m simbox add 8901 5551234
+python -m simbox list
+```
+
+## Running tests
+
+Install pytest and run:
+
+```bash
+pytest
+```

--- a/simbox/__init__.py
+++ b/simbox/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ['SimCard', 'SimManager']
+

--- a/simbox/__main__.py
+++ b/simbox/__main__.py
@@ -1,0 +1,45 @@
+import argparse
+from pathlib import Path
+
+from .manager import SimManager
+
+DEFAULT_DB = Path("sims.json")
+
+def main():
+    parser = argparse.ArgumentParser(description="SIM management CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_p = subparsers.add_parser("add", help="Add new SIM")
+    add_p.add_argument("iccid")
+    add_p.add_argument("phone_number")
+
+    list_p = subparsers.add_parser("list", help="List SIMs")
+
+    assign_p = subparsers.add_parser("assign", help="Assign SIM to owner")
+    assign_p.add_argument("iccid")
+    assign_p.add_argument("owner")
+
+    block_p = subparsers.add_parser("block", help="Block SIM")
+    block_p.add_argument("iccid")
+
+    remove_p = subparsers.add_parser("remove", help="Remove SIM")
+    remove_p.add_argument("iccid")
+
+    args = parser.parse_args()
+
+    manager = SimManager(DEFAULT_DB)
+
+    if args.command == "add":
+        manager.add_sim(args.iccid, args.phone_number)
+    elif args.command == "list":
+        for sim in manager.list_sims():
+            print(sim)
+    elif args.command == "assign":
+        manager.assign_sim(args.iccid, args.owner)
+    elif args.command == "block":
+        manager.block_sim(args.iccid)
+    elif args.command == "remove":
+        manager.remove_sim(args.iccid)
+
+if __name__ == "__main__":
+    main()

--- a/simbox/manager.py
+++ b/simbox/manager.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+
+from .sim import SimCard
+
+class SimManager:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self.sims: List[SimCard] = []
+        self.load()
+
+    def load(self) -> None:
+        if self.db_path.exists():
+            data = json.loads(self.db_path.read_text())
+            self.sims = [SimCard(**item) for item in data]
+        else:
+            self.sims = []
+
+    def save(self) -> None:
+        data = [s.__dict__ for s in self.sims]
+        self.db_path.write_text(json.dumps(data, indent=2))
+
+    def list_sims(self) -> List[SimCard]:
+        return list(self.sims)
+
+    def add_sim(self, iccid: str, phone_number: str) -> SimCard:
+        if any(s.iccid == iccid for s in self.sims):
+            raise ValueError(f"SIM {iccid} already exists")
+        sim = SimCard(iccid=iccid, phone_number=phone_number)
+        self.sims.append(sim)
+        self.save()
+        return sim
+
+    def remove_sim(self, iccid: str) -> None:
+        before = len(self.sims)
+        self.sims = [s for s in self.sims if s.iccid != iccid]
+        if len(self.sims) == before:
+            raise ValueError(f"SIM {iccid} not found")
+        self.save()
+
+    def assign_sim(self, iccid: str, owner: str) -> None:
+        sim = self._find(iccid)
+        sim.owner = owner
+        sim.status = "assigned"
+        self.save()
+
+    def block_sim(self, iccid: str) -> None:
+        sim = self._find(iccid)
+        sim.status = "blocked"
+        self.save()
+
+    def _find(self, iccid: str) -> SimCard:
+        for sim in self.sims:
+            if sim.iccid == iccid:
+                return sim
+        raise ValueError(f"SIM {iccid} not found")

--- a/simbox/sim.py
+++ b/simbox/sim.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+@dataclass
+class SimCard:
+    iccid: str
+    phone_number: str
+    status: str = field(default="available")
+    owner: Optional[str] = field(default=None)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,26 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+from pathlib import Path
+
+from simbox.manager import SimManager
+
+
+def test_add_and_list(tmp_path):
+    db = tmp_path / "db.json"
+    mgr = SimManager(db)
+    mgr.add_sim("123", "555")
+    sims = mgr.list_sims()
+    assert len(sims) == 1
+    assert sims[0].iccid == "123"
+
+
+def test_assign_and_block(tmp_path):
+    db = tmp_path / "db.json"
+    mgr = SimManager(db)
+    mgr.add_sim("123", "555")
+    mgr.assign_sim("123", "Alice")
+    sim = mgr.list_sims()[0]
+    assert sim.owner == "Alice"
+    assert sim.status == "assigned"
+    mgr.block_sim("123")
+    assert mgr.list_sims()[0].status == "blocked"


### PR DESCRIPTION
## Summary
- implement `SimCard` dataclass
- implement `SimManager` with JSON persistence
- add CLI entry point for managing SIM cards
- document usage and tests
- provide pytest-based test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b00480f883329fc1064d1f33cde9