### PR TITLE
Add Terraform infrastructure modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,20 @@ python bot.py
 
 Команда `/history` покажет последние анализы, а `/export <id>` пришлёт PDF‑отчёт.
 
+
+## Terraform Modules
+
+В каталоге `terraform` находятся модули для развертывания инфраструктуры:
+
+- `modules/s3-storage` — S3‑совместимое хранилище с включённым шифрованием и правилом удаления файлов через 30 дней.
+- `modules/rds-postgres` — база данных Postgres в Amazon RDS с шифрованием.
+- `modules/message-queue` — кластер Kafka (Amazon MSK) с шифрованием данных.
+- `modules/ecs` — кластер ECS для запуска контейнеров.
+
+Пример использования модулей находится в `terraform/main.tf`. Перед запуском инициализируйте и примените Terraform:
+
+```bash
+cd terraform
+terraform init
+terraform apply
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,50 @@
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "s3" {
+  source         = "./modules/s3-storage"
+  bucket_name    = var.bucket_name
+  force_destroy  = true
+  lifecycle_days = 30
+}
+
+module "rds" {
+  source              = "./modules/rds-postgres"
+  identifier          = var.db_identifier
+  username            = var.db_username
+  password            = var.db_password
+  subnet_group_name   = var.db_subnet_group_name
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = var.security_group_ids
+}
+
+module "mq" {
+  source              = "./modules/message-queue"
+  cluster_name        = var.mq_cluster_name
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = var.security_group_ids
+  kms_key_arn         = var.kms_key_arn
+}
+
+module "ecs" {
+  source       = "./modules/ecs"
+  cluster_name = var.ecs_cluster_name
+}
+
+output "s3_bucket_name" {
+  value = module.s3.bucket_name
+}
+
+output "db_endpoint" {
+  value = module.rds.db_instance_endpoint
+}
+
+output "mq_bootstrap_brokers" {
+  value = module.mq.bootstrap_brokers
+}
+
+output "ecs_cluster_arn" {
+  value = module.ecs.cluster_arn
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,7 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.cluster_name
+}
+
+output "cluster_arn" {
+  value = aws_ecs_cluster.this.arn
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+}

--- a/terraform/modules/message-queue/main.tf
+++ b/terraform/modules/message-queue/main.tf
@@ -1,0 +1,18 @@
+resource "aws_msk_cluster" "this" {
+  cluster_name           = var.cluster_name
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+  broker_node_group_info {
+    instance_type   = var.instance_type
+    client_subnets  = var.subnet_ids
+    security_groups = var.security_group_ids
+  }
+
+  encryption_info {
+    encryption_at_rest_kms_key_arn = var.kms_key_arn
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+}

--- a/terraform/modules/message-queue/outputs.tf
+++ b/terraform/modules/message-queue/outputs.tf
@@ -1,0 +1,3 @@
+output "bootstrap_brokers" {
+  value = aws_msk_cluster.this.bootstrap_brokers_tls
+}

--- a/terraform/modules/message-queue/variables.tf
+++ b/terraform/modules/message-queue/variables.tf
@@ -1,0 +1,37 @@
+variable "cluster_name" {
+  description = "MSK cluster name"
+  type        = string
+}
+
+variable "kafka_version" {
+  description = "Kafka version"
+  type        = string
+  default     = "3.4.0"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of broker nodes"
+  type        = number
+  default     = 2
+}
+
+variable "instance_type" {
+  description = "Broker instance type"
+  type        = string
+  default     = "kafka.t3.small"
+}
+
+variable "subnet_ids" {
+  description = "Subnets for brokers"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security groups"
+  type        = list(string)
+}
+
+variable "kms_key_arn" {
+  description = "KMS key arn for encryption at rest"
+  type        = string
+}

--- a/terraform/modules/rds-postgres/main.tf
+++ b/terraform/modules/rds-postgres/main.tf
@@ -1,0 +1,18 @@
+resource "aws_db_subnet_group" "this" {
+  name       = var.subnet_group_name
+  subnet_ids = var.subnet_ids
+}
+
+resource "aws_db_instance" "this" {
+  identifier               = var.identifier
+  engine                   = "postgres"
+  engine_version           = var.engine_version
+  instance_class           = var.instance_class
+  allocated_storage        = var.allocated_storage
+  username                 = var.username
+  password                 = var.password
+  db_subnet_group_name     = aws_db_subnet_group.this.name
+  vpc_security_group_ids   = var.security_group_ids
+  storage_encrypted        = true
+  skip_final_snapshot      = var.skip_final_snapshot
+}

--- a/terraform/modules/rds-postgres/outputs.tf
+++ b/terraform/modules/rds-postgres/outputs.tf
@@ -1,0 +1,3 @@
+output "db_instance_endpoint" {
+  value = aws_db_instance.this.endpoint
+}

--- a/terraform/modules/rds-postgres/variables.tf
+++ b/terraform/modules/rds-postgres/variables.tf
@@ -1,0 +1,54 @@
+variable "identifier" {
+  description = "DB instance identifier"
+  type        = string
+}
+
+variable "engine_version" {
+  description = "Postgres engine version"
+  type        = string
+  default     = "15"
+}
+
+variable "instance_class" {
+  description = "DB instance class"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "allocated_storage" {
+  description = "Storage in GB"
+  type        = number
+  default     = 20
+}
+
+variable "username" {
+  description = "Master username"
+  type        = string
+}
+
+variable "password" {
+  description = "Master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "subnet_group_name" {
+  description = "DB subnet group name"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet ids"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group ids"
+  type        = list(string)
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot on destroy"
+  type        = bool
+  default     = true
+}

--- a/terraform/modules/s3-storage/main.tf
+++ b/terraform/modules/s3-storage/main.tf
@@ -1,0 +1,28 @@
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket_name
+  force_destroy = var.force_destroy
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "auto-delete"
+    status = "Enabled"
+    filter {}
+
+    expiration {
+      days = var.lifecycle_days
+    }
+  }
+}

--- a/terraform/modules/s3-storage/outputs.tf
+++ b/terraform/modules/s3-storage/outputs.tf
@@ -1,0 +1,3 @@
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}

--- a/terraform/modules/s3-storage/variables.tf
+++ b/terraform/modules/s3-storage/variables.tf
@@ -1,0 +1,16 @@
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+}
+
+variable "force_destroy" {
+  description = "Delete objects with bucket"
+  type        = bool
+  default     = false
+}
+
+variable "lifecycle_days" {
+  description = "Days before objects expire"
+  type        = number
+  default     = 30
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,56 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "db_identifier" {
+  description = "Identifier for RDS instance"
+  type        = string
+}
+
+variable "db_username" {
+  description = "RDS master username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "RDS master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_subnet_group_name" {
+  description = "Subnet group name for RDS"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Common subnet IDs"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Common security group IDs"
+  type        = list(string)
+}
+
+variable "mq_cluster_name" {
+  description = "Kafka cluster name"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN for encryption"
+  type        = string
+}
+
+variable "ecs_cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform modules for AWS resources (S3, RDS Postgres, Kafka MSK, ECS)
- enable auto-deletion of bucket objects after 30 days
- document new Terraform modules in README

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687ba82cb6c88332b796ebab11cc9d81